### PR TITLE
Moving event registering before table initialization

### DIFF
--- a/Tools/GameEvents.lua
+++ b/Tools/GameEvents.lua
@@ -38,8 +38,8 @@ function GameEvents.registerHandler(event, callback)
 	assert(Ellyb.Assertions.isType(callback, "function", "callback"));
 
 	if not REGISTERED_EVENTS[event] then
-		REGISTERED_EVENTS[event] = {};
 		EventFrame:RegisterEvent(event);
+		REGISTERED_EVENTS[event] = {};
 		Logger:Info(format(REGISTERED_EVENT, tostring(event)))
 	end
 


### PR DESCRIPTION
This change is preparing for BfA.

Since registering an unknown event now throws an error, I'd like the error to be thrown before initializing the table. If it's not, trying to register the wrong event a second time won't actually throw an error since the table isn't nil anymore.

I think we still want the table to be cleared before trying to unregister an unknown event though, just in case. Doesn't matter for me as I won't ask to unregister an unknown event (since registering will fail).