### PR TITLE
Feature/assertions improvements

### DIFF
--- a/Configuration/Configuration.lua
+++ b/Configuration/Configuration.lua
@@ -6,7 +6,6 @@ if Ellyb.Configuration then
 end
 
 -- Lua imports
-local assert = assert;
 local format = format;
 local type = type;
 local pairs = pairs;
@@ -23,7 +22,7 @@ local CONFIGURATION_KEY_ALREADY_EXISTS = [[Configuration key %s has already been
 ---Constructor
 ---@param savedVariablesName string @ The saved variable name, used to access the table from _G
 function Configuration:initialize(savedVariablesName)
-	assert(isType(savedVariablesName, "string", "savedVariablesName"));
+	Ellyb.Assertions.isType(savedVariablesName, "string", "savedVariablesName");
 
 	_private[self] = {};
 	_private[self].savedVariablesName = savedVariablesName;
@@ -41,7 +40,7 @@ end
 ---@param configurationKey string @ A new configuration key
 ---@param defaultValue any @ The default value for this new configuration key
 function Configuration:RegisterConfigKey(configurationKey, defaultValue)
-	assert(isType(configurationKey, "string", "configurationKey"));
+	Ellyb.Assertions.isType(configurationKey, "string", "configurationKey");
 	assert(not self:IsConfigurationKeyRegistered(configurationKey), format(CONFIGURATION_KEY_ALREADY_EXISTS, configurationKey));
 
 	_private[self].defaultValues[configurationKey] = defaultValue;
@@ -55,7 +54,7 @@ end
 ---@param configurationKey string @ A valid configuration key
 ---@return boolean isRegistered @ True if the configuration has already been registered
 function Configuration:IsConfigurationKeyRegistered(configurationKey)
-	assert(isType(configurationKey, "string", "configurationKey"));
+	Ellyb.Assertions.isType(configurationKey, "string", "configurationKey");
 	return _private[self].defaultValues[configurationKey] ~= nil;
 end
 
@@ -69,7 +68,7 @@ end
 ---@param configurationKey string @ A valid configuration key that has previously been registered
 ---@param value any @ The new value for the configuration key
 function Configuration:SetValue(configurationKey, value)
-	assert(isType(configurationKey, "string", "configurationKey"));
+	Ellyb.Assertions.isType(configurationKey, "string", "configurationKey");
 	assert(self:IsConfigurationKeyRegistered(configurationKey), format(UNKNOWN_CONFIGURATION_KEY, configurationKey));
 
 	local savedVariables = _G[_private[self].savedVariablesName];
@@ -82,7 +81,7 @@ end
 --- Reset the value of a configuration key to its default value
 ---@param configurationKey string @ A valid configuration key that has previously been registered
 function Configuration:ResetValue(configurationKey)
-	assert(isType(configurationKey, "string", "configurationKey"));
+	Ellyb.Assertions.isType(configurationKey, "string", "configurationKey");
 	assert(self:IsConfigurationKeyRegistered(configurationKey), format(UNKNOWN_CONFIGURATION_KEY, configurationKey));
 
 	self:SetValue(configurationKey, _private[self].defaultValues[configurationKey]);

--- a/Configuration/Configuration.lua
+++ b/Configuration/Configuration.lua
@@ -10,9 +10,6 @@ local format = format;
 local type = type;
 local pairs = pairs;
 
--- Ellyb imports
-local isType = Ellyb.Assertions.isType;
-
 ---@class Configuration
 local Configuration, _private = Ellyb.Class("Configuration");
 

--- a/Documentation/Assertions.lua
+++ b/Documentation/Assertions.lua
@@ -1,7 +1,7 @@
 ---@type Ellyb
 local Ellyb = Ellyb(...);
 
--- IDE shortcut to go to module
+-- IDE shortcut to quickly go to related module
 local _ = Ellyb.Assertions;
 
 Ellyb.Documentation:AddDocumentationTable("Ellyb.Assertions", {
@@ -21,11 +21,6 @@ Can also check for Widget type ("Frame", "Button", "Texture")]] },
 				{ Name = "expectedType", Type = "string", Documentation = { "Expected type of the variable" } },
 				{ Name = "variableName", Type = "string", Documentation = { "The name of the variable being tested, will be visible in the error message" } },
 			},
-
-			Returns = {
-				{ Name = "isType", Type = "boolean", Nilable = false, Documentation = { "Returns true if the variable was of the expected type, or false." } },
-				{ Name = "errorMessage", Type = "string", Nilable = true, Documentation = { "Error message if the variable wasn't of the right type." } },
-			},
 		},
 		{
 			Name = "isOfTypes",
@@ -38,11 +33,6 @@ Can also check for Widget types ("Frame", "Button", "Texture")]] },
 				{ Name = "expectedTypes", Type = "table", Documentation = { "A list of expected types for the variable" } },
 				{ Name = "variableName", Type = "string", Documentation = { "The name of the variable being tested, will be visible in the error message" } },
 			},
-
-			Returns = {
-				{ Name = "isType", Type = "boolean", Nilable = false, Documentation = { "Returns true if the variable was of the expected type, or false." } },
-				{ Name = "errorMessage", Type = "string", Nilable = true, Documentation = { "Error message if the variable wasn't of the right type." } },
-			},
 		},
 		{
 			Name = "isNotNil",
@@ -52,11 +42,6 @@ Can also check for Widget types ("Frame", "Button", "Texture")]] },
 			Arguments = {
 				{ Name = "variable", Type = "any", Documentation = { "Any kind of variable, to be tested for its type" } },
 				{ Name = "variableName", Type = "string", Documentation = { "The name of the variable being tested, will be visible in the error message" } },
-			},
-
-			Returns = {
-				{ Name = "isNotNil", Type = "boolean", Nilable = false, Documentation = { "true if the variable was not nil, or false." } },
-				{ Name = "errorMessage", Type = "string", Nilable = true, Documentation = { "Error message if the variable was nil." } },
 			},
 		},
 		{
@@ -69,10 +54,6 @@ Can also check for Widget types ("Frame", "Button", "Texture")]] },
 				{ Name = "variableName", Type = "string", Documentation = { "The name of the variable being tested, will be visible in the error message" } },
 			},
 
-			Returns = {
-				{ Name = "isNotEmpty", Type = "boolean", Nilable = false, Documentation = { "true if the variable was not empty, or false." } },
-				{ Name = "errorMessage", Type = "string", Nilable = true, Documentation = { "Error message if the variable was empty." } },
-			},
 		},
 		{
 			Name = "isInstanceOf",
@@ -81,14 +62,10 @@ Can also check for Widget types ("Frame", "Button", "Texture")]] },
 
 			Arguments = {
 				{ Name = "variable", Type = "any", Documentation = { "Any kind of variable, to be tested for its type" } },
-				{ Name = "class", Type = "string", Documentation = { "The name of the expected class as a string" } },
+				{ Name = "class", Type = "string", Documentation = { "A direct reference to the class definition" } },
 				{ Name = "variableName", Type = "string", Documentation = { "The name of the variable being tested, will be visible in the error message" } },
 			},
 
-			Returns = {
-				{ Name = "isInstance", Type = "boolean", Nilable = false, Documentation = { "true if the variable was an instance of the given class, or false." } },
-				{ Name = "errorMessage", Type = "string", Nilable = true, Documentation = { "Error message if the variable was not an instance of the given class." } },
-			},
 		},
 		{
 			Name = "isOneOf",
@@ -101,10 +78,6 @@ Can also check for Widget types ("Frame", "Button", "Texture")]] },
 				{ Name = "variableName", Type = "string", Documentation = { "The name of the variable being tested, will be visible in the error message" } },
 			},
 
-			Returns = {
-				{ Name = "isValid", Type = "boolean", Nilable = false, Documentation = { "true if the variable was one of the given values, or false." } },
-				{ Name = "errorMessage", Type = "string", Nilable = true, Documentation = { "Error message if the variable was not one of the given values." } },
-			},
 		},
 		{
 			Name = "numberIsBetween",
@@ -118,10 +91,6 @@ Can also check for Widget types ("Frame", "Button", "Texture")]] },
 				{ Name = "variableName", Type = "string", Documentation = { "The name of the variable being tested, will be visible in the error message" } },
 			},
 
-			Returns = {
-				{ Name = "isValid", Type = "boolean", Nilable = false, Documentation = { "true if the variable was a number between the boundaries, or false." } },
-				{ Name = "errorMessage", Type = "string", Nilable = true, Documentation = { "Error message if the variable was not between the boundaries or was not a number." } },
-			},
 		},
 	},
 });

--- a/Ellyb.lua
+++ b/Ellyb.lua
@@ -4,7 +4,7 @@ local AddOnName = ...;
 local pairs = pairs;
 -- local assert = assert;
 
-local VERSION_NUMBER = 6;
+local VERSION_NUMBER = 7;
 local DEBUG_MODE = true;
 local instances = {};
 local addonVersions = {};

--- a/Tools/Assertions.lua
+++ b/Tools/Assertions.lua
@@ -1,67 +1,67 @@
 ---@type Ellyb
-local Ellyb = Ellyb(...);
+local Ellyb = Ellyb(...)
 
 if Ellyb.Assertions then
 	return
 end
 
----@class Assertions
 --- Various assertion functions to check if variables are of a certain type, empty, nil etc.
 --- These assertions will directly raise an error if the test is not met.
-local Assertions = {};
+local Assertions = {}
+
+--{{{ Helpers
+
+--- Throws an error in the parent's scope
+---@param message string
+local function throw(message)
+	error(message, 3)
+end
+
+---@param variable UIObject
+local function isUIObject(variable)
+	return type(variable) == "table" and type(variable.GetObjectType) == "function"
+end
+
+---@param variable MiddleClass_Class
+local function isAClass(variable)
+	return type(variable) == "table" and type(variable.IsInstanceOf) == "function"
+end
+
+---@param t table
+---@return string
+local function list(t)
+	return table.concat(t, ", ")
+end
+
+--}}}
 
 --- Check if a variable is of the expected type ("number", "boolean", "string")
 --- Can also check for Widget type ("Frame", "Button", "Texture")
----@param variable any Any kind of variable, to be tested for its type
+---@param variable any|UIObject Any kind of variable, to be tested for its type
 ---@param expectedType string Expected type of the variable
 ---@param variableName string The name of the variable being tested, will be visible in the error message
 ---@return boolean, string Returns true if the variable was of the expected type, or false with an error message if it wasn't.
 function Assertions.isType(variable, expectedType, variableName)
-	local variableType = type(variable)
-	local isOfExpectedType = variableType == expectedType
-
-	if not isOfExpectedType then
-		-- Special check for frames. If a variable is a table, it could be a Frame.
-		if variableType == "table" and type(variable.IsObjectType) == "function" then
-			if not variable:IsObjectType(expectedType) then
-				error(([[Invalid Widget type "%s" for variable "%s", expected a "%s".]]):format(variable:GetObjectType(), variableName, expectedType), 2)
-			end
-		else
-			error(([[Invalid variable type "%s" for variable "%s", expected "%s".]]):format(variableType, variableName, expectedType), 2)
-		end
+	if isUIObject(variable) and not variable:IsObjectType(expectedType) then
+		throw(([[Invalid Widget type "%s" for variable "%s", expected a "%s".]]):format(variable:GetObjectType(), variableName, expectedType))
+	end
+	if type(variable) ~= expectedType then
+		throw(([[Invalid variable type "%s" for variable "%s", expected "%s".]]):format(type(variable), variableName, expectedType))
 	end
 end
 
 ---Check if a variable is of one of the types expected ("number", "boolean", "string")
 ------Can also check for Widget types ("Frame", "Button", "Texture")
----@param variable any Any kind of variable, to be tested for its type
+---@param variable any|UIObject Any kind of variable, to be tested for its type
 ---@param expectedTypes string[] A list of expected types for the variable
 ---@param variableName string The name of the variable being tested, will be visible in the error message
 ---@return boolean, string Returns true if the variable was of the expected type, or false with an error message if it wasn't.
 function Assertions.isOfTypes(variable, expectedTypes, variableName)
-	local variableType = type(variable);
-	local isOfExpectedType = false;
-	local isUIObject = variableType == "table" and type(variable.IsObjectType) == "function";
-
-	for _, expectedType in pairs(expectedTypes) do
-		if isUIObject then
-			if variable:IsObjectType(expectedType) then
-				isOfExpectedType = true;
-				break;
-			end
-		elseif variableType == expectedType then
-			isOfExpectedType = true;
-			break;
-		end
+	if isUIObject(variable) and not tContains(expectedTypes, variable:GetObjectType()) then
+		throw(([[Invalid Widget type "%s" for variable "%s", expected one of {%s}.]]):format(variable:GetObjectType(), variableName, list(expectedTypes)))
 	end
-
-	if not isOfExpectedType then
-		local expectedTypesString = table.concat(expectedTypes, ", ");
-		if isUIObject then
-			error(([[Invalid Widget type "%s" for variable "%s", expected one of {%s}.]]):format(variable:GetObjectType(), variableName, expectedTypesString), 2)
-		else
-			error(([[Invalid variable type "%s" for variable "%s", expected one of {%s}.]]):format(variableType, variableName, expectedTypesString), 2)
-		end
+	if not tContains(expectedTypes, type(variable)) then
+		throw(([[Invalid variable type "%s" for variable "%s", expected one of {%s}.]]):format(type(variable), variableName, list(expectedTypes)))
 	end
 end
 
@@ -71,7 +71,7 @@ end
 ---@return boolean, string Returns true if the variable was not nil, or false with an error message if it wasn't.
 function Assertions.isNotNil(variable, variableName)
 	if variable == nil then
-		error(([[Unexpected nil variable "%s".]]):format(variableName), 2)
+		throw(([[Unexpected nil variable "%s".]]):format(variableName))
 	end
 end
 
@@ -80,18 +80,17 @@ end
 ---@param variableName string The name of the variable being tested, will be visible in the error message
 ---@return boolean, string Returns true if the variable was not empty, or false with an error message if it was.
 function Assertions.isNotEmpty(variable, variableName)
-	local variableType = type(variable);
-
-	if variableType == "nil" then
-		error(([[Variable "%s" cannot be empty.]]):format(variableName), 2)
-
+	if variable == nil then
+		throw(([[Variable "%s" cannot be empty.]]):format(variableName))
+	end
 	-- To check if a table is empty we can just try to get its next field
-	elseif variableType == "table" and not next(variable) then
-		error(([[Variable "%s" cannot be an empty table.]]):format(variableName), 2)
+	if type(variable) == "table" and not next(variable) then
+		throw(([[Variable "%s" cannot be an empty table.]]):format(variableName))
+	end
 
-		-- A string is considered empty if it is equal to empty string ""
-	elseif variableType == "string" then
-		error(([[Variable "%s" cannot be an empty string.]]):format(variableName), 2)
+	-- A string is considered empty if it is equal to empty string ""
+	if type(variable) == "string" and variable == "" then
+		throw(([[Variable "%s" cannot be an empty string.]]):format(variableName))
 	end
 end
 
@@ -100,19 +99,12 @@ end
 ---@param class MiddleClass_Class A direct reference to the expected class
 ---@param variableName string The name of the variable being tested, will be visible in the error message
 function Assertions.isInstanceOf(variable, class, variableName)
-	local variableType = type(variable);
-
-	if variableType ~= "table" or not variable.IsInstanceOf or not variable.class then
-		-- The variable is not a Class
-		error(([[Invalid type "%s" for variable "%s", expected a "%s".]]):format(variableType, variableName, tostring(class)), 2)
+	if not isAClass(variable) then
+		throw(([[Invalid type "%s" for variable "%s", expected a "%s".]]):format(type(variable), variableName, tostring(class)))
 	end
-
-	-- Check if the variable is an instance of the given class (taking polymorphism into account)
 	if not variable:IsInstanceOf(class) then
-		-- The variable is an instance of a different class
-		error(([[Invalid Class "%s" for variable "%s", expected "%s".]]):format(tostring(variable.class), variableName, tostring(class)), 2)
+		throw(([[Invalid Class "%s" for variable "%s", expected "%s".]]):format(tostring(variable.class), variableName, tostring(class)))
 	end
-
 end
 
 
@@ -121,13 +113,9 @@ end
 ---@param possibleValues table A table of the possible values accepted
 ---@param variableName string The name of the variable being tested, will be visible in the error message
 function Assertions.isOneOf(variable, possibleValues, variableName)
-	for _, possibleValue in pairs(possibleValues) do
-		if variable == possibleValue then
-			return
-		end
+	if not tContains(possibleValues, variable) then
+		throw(([[Unexpected variable value %s for variable "%s", expected to be one of {%s}.]]):format(tostring(variable), variableName, list(possibleValues)))
 	end
-
-	error(([[Unexpected variable value %s for variable "%s", expected to be one of {%s}.]]):format(tostring(variable), variableName, table.concat(possibleValues, ", ")), 2)
 end
 
 --- Check if a variable is a number between a maximum and a minimum
@@ -139,11 +127,11 @@ function Assertions.numberIsBetween(variable, minimum, maximum, variableName)
 
 	-- Variable has to be a number to do comparison
 	if type(variable) ~= "number" then
-		error(([[Invalid variable type "%s" for variable "%s", expected "number".]]):format(type(variable), variableName), 2)
+		throw(([[Invalid variable type "%s" for variable "%s", expected "number".]]):format(type(variable), variableName))
 	end
 
 	if variable < minimum or variable > maximum then
-		error(([[Invalid variable value "%s" for variable "%s". Expected the value to be between "%s" and "%s"]]):format(variable, variableName, minimum, maximum), 2)
+		throw(([[Invalid variable value "%s" for variable "%s". Expected the value to be between "%s" and "%s"]]):format(variable, variableName, minimum, maximum))
 	end
 
 end

--- a/Tools/Assertions.lua
+++ b/Tools/Assertions.lua
@@ -5,70 +5,40 @@ if Ellyb.Assertions then
 	return
 end
 
--- WoW imports
-local type = type;
-local format = string.format;
-local next = next;
-local pairs = pairs;
-local concat = table.concat;
-local tostring = tostring;
-
 ---@class Assertions
 --- Various assertion functions to check if variables are of a certain type, empty, nil etc.
---- These assertions will check if the library is running in DEBUG_MODE and only execute the assertions then.
---- When not in DEBUG_MODE the assertions will be passed and will always return true, suppressing potential overhead
+--- These assertions will directly raise an error if the test is not met.
 local Assertions = {};
-Ellyb.Assertions = Assertions;
 
--- Error messages
-local DEBUG_NIL_VARIABLE = [[Unexpected nil variable "%s".]];
-local DEBUG_WRONG_VARIABLE_TYPE = [[Invalid variable type "%2$s" for variable "%1$s", expected "%3$s".]];
-local DEBUG_WRONG_WIDGET_TYPE = [[Invalid Widget type "%2$s" for variable "%1$s", expected a "%3$s".]];
-local DEBUG_WRONG_VARIABLE_TYPES = [[Invalid variable type "%2$s" for variable "%1$s", expected one of (%3$s).]];
-local DEBUG_WRONG_WIDGET_TYPES = [[Invalid Widget type "%2$s" for variable "%1$s", expected one of (%3$s).]];
-local DEBUG_EMPTY_VARIABLE = [[Variable "%s" cannot be empty.]];
-local DEBUG_WRONG_CLASS = [[Invalid Class "%2$s" for variable "%1$s", expected "%3$s".]];
-local DEBUG_UNEXPECTED_VALUE = [[Unexpected variable value %2$s for variable "%1$s", expected to be one of (%3$s).]];
-local DEBUG_WRONG_VARIABLE_INTERVAL = [[Invalid variable value "%2$s" for variable "%1$s". Expected the value to be between "%3$s" and "%4$s"]];
-
----Check if a variable is of the expected type ("number", "boolean", "string")
----Can also check for Widget type ("Frame", "Button", "Texture")
----@param variable any @ Any kind of variable, to be tested for its type
----@param expectedType string @ Expected type of the variable
----@param variableName string @ The name of the variable being tested, will be visible in the error message
----@return boolean, string isType, errorMessage @ Returns true if the variable was of the expected type, or false with an error message if it wasn't.
+--- Check if a variable is of the expected type ("number", "boolean", "string")
+--- Can also check for Widget type ("Frame", "Button", "Texture")
+---@param variable any Any kind of variable, to be tested for its type
+---@param expectedType string Expected type of the variable
+---@param variableName string The name of the variable being tested, will be visible in the error message
+---@return boolean, string Returns true if the variable was of the expected type, or false with an error message if it wasn't.
 function Assertions.isType(variable, expectedType, variableName)
-	if not Ellyb:IsDebugModeEnabled() then
-		return true
-	end;
-	local variableType = type(variable);
-	local isOfExpectedType = variableType == expectedType;
+	local variableType = type(variable)
+	local isOfExpectedType = variableType == expectedType
+
 	if not isOfExpectedType then
 		-- Special check for frames. If a variable is a table, it could be a Frame.
 		if variableType == "table" and type(variable.IsObjectType) == "function" then
-			if variable:IsObjectType(expectedType) then
-				return true;
-			else
-				return false, format(DEBUG_WRONG_WIDGET_TYPE, variableName, variableType, expectedType);
+			if not variable:IsObjectType(expectedType) then
+				error(([[Invalid Widget type "%s" for variable "%s", expected a "%s".]]):format(variable:GetObjectType(), variableName, expectedType), 2)
 			end
 		else
-			return false, format(DEBUG_WRONG_VARIABLE_TYPE, variableName, variableType, expectedType);
+			error(([[Invalid variable type "%s" for variable "%s", expected "%s".]]):format(variableType, variableName, expectedType), 2)
 		end
-	else
-		return true;
 	end
 end
 
 ---Check if a variable is of one of the types expected ("number", "boolean", "string")
 ------Can also check for Widget types ("Frame", "Button", "Texture")
----@param variable any @ Any kind of variable, to be tested for its type
----@param expectedTypes string[] @ A list of expected types for the variable
----@param variableName string @ The name of the variable being tested, will be visible in the error message
----@return boolean, string isType, errorMessage @ Returns true if the variable was of the expected type, or false with an error message if it wasn't.
+---@param variable any Any kind of variable, to be tested for its type
+---@param expectedTypes string[] A list of expected types for the variable
+---@param variableName string The name of the variable being tested, will be visible in the error message
+---@return boolean, string Returns true if the variable was of the expected type, or false with an error message if it wasn't.
 function Assertions.isOfTypes(variable, expectedTypes, variableName)
-	if not Ellyb:IsDebugModeEnabled() then
-		return true
-	end;
 	local variableType = type(variable);
 	local isOfExpectedType = false;
 	local isUIObject = variableType == "table" and type(variable.IsObjectType) == "function";
@@ -86,121 +56,96 @@ function Assertions.isOfTypes(variable, expectedTypes, variableName)
 	end
 
 	if not isOfExpectedType then
-		local expectedTypesString = concat(expectedTypes, "|");
+		local expectedTypesString = table.concat(expectedTypes, ", ");
 		if isUIObject then
-			return false, format(DEBUG_WRONG_WIDGET_TYPES, variableName, variableType, expectedTypesString);
+			error(([[Invalid Widget type "%s" for variable "%s", expected one of {%s}.]]):format(variable:GetObjectType(), variableName, expectedTypesString), 2)
 		else
-			return false, format(DEBUG_WRONG_VARIABLE_TYPES, variableName, variableType, expectedTypesString);
+			error(([[Invalid variable type "%s" for variable "%s", expected one of {%s}.]]):format(variableType, variableName, expectedTypesString), 2)
 		end
-	else
-		return true;
 	end
 end
 
 ---Check if a variable is not nil
----@param variable any @ Any kind of variable, will be checked if it is nil
----@param variableName string @ The name of the variable being tested, will be visible in the error message
----@return boolean, string isNotNil, errorMessage @ Returns true if the variable was not nil, or false with an error message if it wasn't.
+---@param variable any Any kind of variable, will be checked if it is nil
+---@param variableName string The name of the variable being tested, will be visible in the error message
+---@return boolean, string Returns true if the variable was not nil, or false with an error message if it wasn't.
 function Assertions.isNotNil(variable, variableName)
-	if not Ellyb:IsDebugModeEnabled() then
-		return true
-	end;
-	local isVariableNil = variable == nil;
-	if isVariableNil then
-		return false, format(DEBUG_NIL_VARIABLE, variableName);
-	else
-		return true;
+	if variable == nil then
+		error(([[Unexpected nil variable "%s".]]):format(variableName), 2)
 	end
 end
 
 ---Check if a variable is empty
----@param variable any @ Any kind of variable that can be checked to be empty
----@param variableName string @ The name of the variable being tested, will be visible in the error message
----@return boolean, string isNotEmpty, errorMessage @ Returns true if the variable was not empty, or false with an error message if it was.
+---@param variable any Any kind of variable that can be checked to be empty
+---@param variableName string The name of the variable being tested, will be visible in the error message
+---@return boolean, string Returns true if the variable was not empty, or false with an error message if it was.
 function Assertions.isNotEmpty(variable, variableName)
-	if not Ellyb:IsDebugModeEnabled() then
-		return true
-	end;
 	local variableType = type(variable);
-	local isEmpty = false;
 
 	if variableType == "nil" then
-		isEmpty = true;
-	elseif variableType == "table" then
-		-- To check if a table is empty we can just try to get its next field
-		isEmpty = not next(variable);
-	elseif variableType == "string" then
-		-- A string is considered empty if it is equal to empty string ""
-		isEmpty = variable == "";
-	end
+		error(([[Variable "%s" cannot be empty.]]):format(variableName), 2)
 
-	if isEmpty then
-		return false, format(DEBUG_EMPTY_VARIABLE, variableName);
-	else
-		return true;
+	-- To check if a table is empty we can just try to get its next field
+	elseif variableType == "table" and not next(variable) then
+		error(([[Variable "%s" cannot be an empty table.]]):format(variableName), 2)
+
+		-- A string is considered empty if it is equal to empty string ""
+	elseif variableType == "string" then
+		error(([[Variable "%s" cannot be an empty string.]]):format(variableName), 2)
 	end
 end
 
 --- Check if a variable is an instance of a specified class, taking polymorphism into account, so inherited class will pass the test.
----@param variable Object @ The object to test
----@param class string @ The name of the expected class as a string
----@param variableName string @ The name of the variable being tested, will be visible in the error message
+---@param variable MiddleClass_Class The object to test
+---@param class MiddleClass_Class A direct reference to the expected class
+---@param variableName string The name of the variable being tested, will be visible in the error message
 function Assertions.isInstanceOf(variable, class, variableName)
-	if not Ellyb:IsDebugModeEnabled() then
-		return true
-	end;
 	local variableType = type(variable);
 
-	if not variableType == "table" or not variable.IsInstanceOf or not variable.class then
+	if variableType ~= "table" or not variable.IsInstanceOf or not variable.class then
 		-- The variable is not a Class
-		return false, format(DEBUG_WRONG_CLASS, variableName, variableType, tostring(class));
+		error(([[Invalid type "%s" for variable "%s", expected a "%s".]]):format(variableType, variableName, tostring(class)), 2)
 	end
 
 	-- Check if the variable is an instance of the given class (taking polymorphism into account)
 	if not variable:IsInstanceOf(class) then
 		-- The variable is an instance of a different class
-		return false, format(DEBUG_WRONG_CLASS, variableName, tostring(variable.class), class);
+		error(([[Invalid Class "%s" for variable "%s", expected "%s".]]):format(tostring(variable.class), variableName, tostring(class)), 2)
 	end
 
-	return true;
 end
 
 
 --- Check if a variable value is one of the possible values.
----@param variable any @ Any kind of variable, will be checked if it's value is in the list of possible values
----@param possibleValues table @ A table of the possible values accepted
----@param variableName string @ The name of the variable being tested, will be visible in the error message
+---@param variable any Any kind of variable, will be checked if it's value is in the list of possible values
+---@param possibleValues table A table of the possible values accepted
+---@param variableName string The name of the variable being tested, will be visible in the error message
 function Assertions.isOneOf(variable, possibleValues, variableName)
-	if not Ellyb:IsDebugModeEnabled() then
-		return true
-	end;
 	for _, possibleValue in pairs(possibleValues) do
 		if variable == possibleValue then
-			return true;
+			return
 		end
 	end
-	return false, format(DEBUG_UNEXPECTED_VALUE, variableName, tostring(variable), concat(possibleValues, "|"));
+
+	error(([[Unexpected variable value %s for variable "%s", expected to be one of {%s}.]]):format(tostring(variable), variableName, table.concat(possibleValues, ", ")), 2)
 end
 
 --- Check if a variable is a number between a maximum and a minimum
----@param variable number @ A number to check
----@param minimum number @ The minimum value for the number
----@param maximum number @ The maximum value for the number
----@param variableName string @ The name of the variable being tested, will be visible in the error message
+---@param variable number A number to check
+---@param minimum number The minimum value for the number
+---@param maximum number The maximum value for the number
+---@param variableName string The name of the variable being tested, will be visible in the error message
 function Assertions.numberIsBetween(variable, minimum, maximum, variableName)
-	if not Ellyb:IsDebugModeEnabled() then
-		return true
-	end;
-	local variableType = type(variable);
 
 	-- Variable has to be a number to do comparison
-	if variableType ~= "number" then
-		return false, format(DEBUG_WRONG_VARIABLE_TYPE, variableName, variableType, "number");
+	if type(variable) ~= "number" then
+		error(([[Invalid variable type "%s" for variable "%s", expected "number".]]):format(type(variable), variableName), 2)
 	end
 
 	if variable < minimum or variable > maximum then
-		return false, format(DEBUG_WRONG_VARIABLE_INTERVAL, variableName, variable, minimum, maximum);
+		error(([[Invalid variable value "%s" for variable "%s". Expected the value to be between "%s" and "%s"]]):format(variable, variableName, minimum, maximum), 2)
 	end
 
-	return true
 end
+
+Ellyb.Assertions = Assertions;

--- a/Tools/Colors.lua
+++ b/Tools/Colors.lua
@@ -6,7 +6,6 @@ if Ellyb.Color then
 end
 
 -- Lua imports
-local assert = assert;
 local abs = math.abs;
 local fmod = math.fmod;
 local min = math.min;

--- a/Tools/Colors.lua
+++ b/Tools/Colors.lua
@@ -18,10 +18,6 @@ local format = string.format;
 local uppercase = string.upper;
 local type = type;
 
--- Ellyb imports
-local isType = Ellyb.Assertions.isType;
-local numberIsBetween = Ellyb.Assertions.numberIsBetween;
-
 ---@class Color : Object
 --- A Color object with various methods used to handle color, color text, etc.
 local Color, _private = Ellyb.Class("Color");
@@ -178,7 +174,7 @@ end
 ---@param red number @ A number between 0 and 1 for the red value
 function Color:SetRed(red)
 	if _private[self].canBeMutated then
-		assert(numberIsBetween(red, 0, 1, "red"));
+		Ellyb.Assertions.numberIsBetween(red, 0, 1, "red");
 		_private[self].red = red;
 	end
 end
@@ -188,7 +184,7 @@ end
 ---@param green number @ A number between 0 and 1 for the green value
 function Color:SetGreen(green)
 	if _private[self].canBeMutated then
-		assert(numberIsBetween(green, 0, 1, "green"));
+		Ellyb.Assertions.numberIsBetween(green, 0, 1, "green");
 		_private[self].green = green;
 	end
 end
@@ -198,7 +194,7 @@ end
 ---@param blue number @ A number between 0 and 1 for the blue value
 function Color:SetBlue(blue)
 	if _private[self].canBeMutated then
-		assert(numberIsBetween(blue, 0, 1, "blue"));
+		Ellyb.Assertions.numberIsBetween(blue, 0, 1, "blue");
 		_private[self].blue = blue;
 	end
 end
@@ -208,7 +204,7 @@ end
 ---@param alpha number @ A number between 0 and 1 for the alpha value
 function Color:SetAlpha(alpha)
 	if _private[self].canBeMutated and alpha then
-		assert(numberIsBetween(alpha, 0, 1, "alpha"));
+		Ellyb.Assertions.numberIsBetween(alpha, 0, 1, "alpha");
 		_private[self].alpha = alpha;
 	end
 end
@@ -322,9 +318,9 @@ end
 ---@param optional alphaIsNotBytes boolean @ Some usage (like color pickers) might want to set the alpha as opacity between 0 and 1.
 ---											 If set to true, alpha will be considered as a value between 0 and 1
 function Color.CreateFromRGBAAsBytes(red, green, blue, alpha, alphaIsNotBytes)
-	assert(numberIsBetween(red, 0, 255, "red"));
-	assert(numberIsBetween(green, 0, 255, "green"));
-	assert(numberIsBetween(blue, 0, 255, "blue"));
+	Ellyb.Assertions.numberIsBetween(red, 0, 255, "red");
+	Ellyb.Assertions.numberIsBetween(green, 0, 255, "green");
+	Ellyb.Assertions.numberIsBetween(blue, 0, 255, "blue");
 
 	-- Manually allocate the class, without calling its constructor and initialize its private properties.
 	---@type Color
@@ -337,7 +333,7 @@ function Color.CreateFromRGBAAsBytes(red, green, blue, alpha, alphaIsNotBytes)
 	if alpha then
 		-- Alpha is optional, only test if we were given a value
 		if not alphaIsNotBytes then
-			assert(numberIsBetween(alpha, 0, 255, "alpha"));
+			Ellyb.Assertions.numberIsBetween(alpha, 0, 255, "alpha");
 			alpha = alpha / 255;
 		end
 		color:SetAlpha(alpha);
@@ -349,7 +345,7 @@ end
 --- Create a new Color from an hexadecimal code
 ---@param hexadecimalColorCode string @ A valid hexadecimal code
 function Color.CreateFromHexa(hexadecimalColorCode)
-	assert(isType(hexadecimalColorCode, "string", "hexadecimalColorCode"));
+	Ellyb.Assertions.isType(hexadecimalColorCode, "string", "hexadecimalColorCode");
 
 	local red, green, blue, alpha = Ellyb.ColorManager.hexaToNumber(hexadecimalColorCode);
 	return Color.CreateFromRGBA(red, green, blue, alpha);

--- a/Tools/EventsDispatcher.lua
+++ b/Tools/EventsDispatcher.lua
@@ -7,11 +7,9 @@ end
 
 -- Lua imports
 local pairs = pairs;
-local assert = assert;
 
 -- Ellyb imports
 local Logger = Ellyb.Logger("Events");
-local isType = Ellyb.Assertions.isType;
 local generateUniqueID = Ellyb.Strings.generateUniqueID;
 
 ---@class EventsDispatcher : Object

--- a/Tools/EventsDispatcher.lua
+++ b/Tools/EventsDispatcher.lua
@@ -32,14 +32,14 @@ function EventsDispatcher:initialize()
 end
 
 function EventsDispatcher:RegisterCallback(event, callback, handlerID)
-	assert(isType(callback, "function", "callback"));
+	Ellyb.Assertions.isType(callback, "function", "callback");
 
 	if not _private[self].callbackRegistry[event] then
 		_private[self].callbackRegistry[event] = {};
 	end
 
 	if handlerID ~= nil then
-		assert(isType(handlerID, "string", "handlerID"));
+		Ellyb.Assertions.isType(handlerID, "string", "handlerID");
 	else
 		handlerID = generateUniqueID(_private[self].callbackRegistry[event]);
 	end
@@ -51,7 +51,7 @@ function EventsDispatcher:RegisterCallback(event, callback, handlerID)
 end
 
 function EventsDispatcher:UnregisterCallback(handlerID)
-	assert(isType(handlerID, "string", "handlerID"));
+	Ellyb.Assertions.isType(handlerID, "string", "handlerID");
 
 	for eventName, eventRegistry in pairs(_private[self].callbackRegistry) do
 		if eventRegistry[handlerID] then

--- a/Tools/GameEvents.lua
+++ b/Tools/GameEvents.lua
@@ -6,7 +6,6 @@ if Ellyb.GameEvents then
 end
 
 -- WoW imports
-local assert = assert;
 local tostring = tostring;
 local format = string.format;
 local CreateFrame = CreateFrame;

--- a/Tools/GameEvents.lua
+++ b/Tools/GameEvents.lua
@@ -29,8 +29,8 @@ local EventFrame = CreateFrame("FRAME");
 ---@param event string @ A game event to listen to
 ---@param callback func @ A callback that will be called when the event is fired with its arguments
 function GameEvents.registerCallback(event, callback, handlerID)
-	assert(Ellyb.Assertions.isType(event, "string", "event"));
-	assert(Ellyb.Assertions.isType(callback, "function", "callback"));
+	Ellyb.Assertions.isType(event, "string", "event");
+	Ellyb.Assertions.isType(callback, "function", "callback");
 
 	if not EventFrame:IsEventRegistered(event) then
 		EventFrame:RegisterEvent(event);
@@ -43,7 +43,7 @@ end
 ---Unregister a previously registered callback using the handler ID given at registration
 ---@param handlerID string @ The handler ID of a previsouly registered callback that we want to unregister
 function GameEvents.unregisterCallback(handlerID)
-	assert(Ellyb.Assertions.isType(handlerID, "string", "handlerID"));
+	Ellyb.Assertions.isType(handlerID, "string", "handlerID");
 
 	eventsDispatcher:UnregisterCallback(handlerID);
 end
@@ -60,7 +60,7 @@ end
 EventFrame:SetScript("OnEvent", dispatchEvent);
 
 function GameEvents.triggerEvent(event, ...)
-	assert(Ellyb.Assertions.isType(event, "string", "event"));
+	Ellyb.Assertions.isType(event, "string", "event");
 	dispatchEvent(EventFrame, event, ...)
 end
 

--- a/Tools/Locale.lua
+++ b/Tools/Locale.lua
@@ -1,23 +1,16 @@
 ---@type Ellyb
 local Ellyb = Ellyb(...);
 
--- Lua imports
-local assert = assert;
-local pairs = pairs;
-
--- Ellyb imports
-local isType = Ellyb.Assertions.isType;
-
 ---@class Locale
 local Locale, _private = Ellyb.Class("Locale");
 
 ---Constructor
 ---@param code string @ The code for the locale, must be one of the game's supported locale code
 ---@param name string @ The name of the locale, as could be displayed to the user
----@param optional content table<string, string> @ Content of the locale, a table with texts indexed with locale keys
+---@param content table<string, string> @ Content of the locale, a table with texts indexed with locale keys
 function Locale:initialize(code, name, content)
-	assert(isType(code, "string", "code"));
-	assert(isType(name, "string", "name"));
+	Ellyb.Assertions.isType(code, "string", "code");
+	Ellyb.Assertions.isType(name, "string", "name");
 
 	_private[self] = {};
 
@@ -55,7 +48,7 @@ end
 ---@param localizationKey string
 ---@return string text
 function Locale:GetText(localizationKey)
-	assert(isType(localizationKey,"string", "localizationKey"));
+	Ellyb.Assertions.isType(localizationKey,"string", "localizationKey");
 
 	return _private[self].content[localizationKey];
 end
@@ -64,8 +57,8 @@ end
 ---@param localizationKey string
 ---@param value string
 function Locale:AddText(localizationKey, value)
-	assert(isType(localizationKey, "string", "localizationKey"));
-	assert(isType(value, "string", "value"));
+	Ellyb.Assertions.isType(localizationKey, "string", "localizationKey");
+	Ellyb.Assertions.isType(value, "string", "value");
 
 	_private[self].content[localizationKey] = value;
 end
@@ -73,7 +66,7 @@ end
 --- Add a table of localization texts to the locale
 ---@param localeTexts table<string, string>
 function Locale:AddTexts(localeTexts)
-	assert(isType(localeTexts, "table", "localeTexts"));
+	Ellyb.Assertions.isType(localeTexts, "table", "localeTexts");
 
 	for localizationKey, value in pairs(localeTexts) do
 		self:AddText(localizationKey, value);

--- a/Tools/Maths.lua
+++ b/Tools/Maths.lua
@@ -5,12 +5,6 @@ if Ellyb.Maths then
 	return
 end
 
--- Lua imports
-local assert = assert;
-
--- Ellyb imports
-local isType = Ellyb.Assertions.isType;
-
 local Maths = {}
 
 --- Increments a given value by the given increments up to a given max.

--- a/Tools/Maths.lua
+++ b/Tools/Maths.lua
@@ -19,9 +19,9 @@ local Maths = {}
 ---@param max number @ The maximum for the value. If value + increment is higher than max, max will be used instead
 ---@return number @ The incremented value
 function Maths.incrementValueUntilMax(value, increment, max)
-	assert(isType(value, "number", "value"));
-	assert(isType(increment, "number", "increment"));
-	assert(isType(max, "number", "max"));
+	Ellyb.Assertions.isType(value, "number", "value");
+	Ellyb.Assertions.isType(increment, "number", "increment");
+	Ellyb.Assertions.isType(max, "number", "max");
 
 	if value + increment > max then
 		return max;

--- a/Tools/SlashCommand.lua
+++ b/Tools/SlashCommand.lua
@@ -64,8 +64,8 @@ function SlashCommand:InitializeCommand(commandKey)
 end
 
 function SlashCommand:RegisterCommand(command, handler, help)
-	assert(isType(command, "string", "command"));
-	assert(isType(handler, "function", "handler"));
+	Ellyb.Assertions.isType(command, "string", "command");
+	Ellyb.Assertions.isType(handler, "function", "handler");
 	command = lowercase(command);
 	assert(not COMMANDS[command], "Already registered command " .. command);
 

--- a/Tools/SlashCommand.lua
+++ b/Tools/SlashCommand.lua
@@ -20,7 +20,6 @@ local _G = _G;
 
 -- Ellyb imports
 local Logger = Ellyb.Logger("SlashCommand");
-local isType = Ellyb.Assertions.isType;
 
 local SlashCommand = {};
 Ellyb.SlashCommand = SlashCommand;

--- a/Tools/Strings/Strings.lua
+++ b/Tools/Strings/Strings.lua
@@ -22,9 +22,6 @@ local insert = table.insert;
 local math = math;
 local tonumber = tonumber;
 
--- Ellyb imports
-local isType = Ellyb.Assertions.isType;
-
 ---@class Strings
 local Strings = {};
 Ellyb.Strings = Strings;

--- a/Tools/Strings/Strings.lua
+++ b/Tools/Strings/Strings.lua
@@ -33,7 +33,7 @@ Ellyb.Strings = Strings;
 ---@param optional customSeparator string @ A custom separator to use to when concatenating the table (default is " ").
 ---@return string
 function Strings.convertTableToString(table, customSeparator)
-	assert(isType(table, "table", "table"));
+	Ellyb.Assertions.isType(table, "table", "table");
 	-- If the table is empty we will just return empty string
 	if Ellyb.Tables.size(table) < 1 then
 		return ""
@@ -60,14 +60,14 @@ VOWELS = tInvert(VOWELS); -- Invert the table so it is easier to check if someth
 ---@param letter string @ A single letter as a string (can be uppercase or lowercase)
 ---@return boolean isAVowel @ True if the letter is a vowel
 function Strings.isAVowel(letter)
-	assert(isType(letter, "string", "letter"));
+	Ellyb.Assertions.isType(letter, "string", "letter");
 	return VOWELS[letter] ~= nil;
 end
 
 ---@param text string
 ---@return string letter @ The first letter in the string that was passed
 function Strings.getFirstLetter(text)
-	assert(isType(text, "string", "text"));
+	Ellyb.Assertions.isType(text, "string", "text");
 	return string.sub(text, 1, 1);
 end
 
@@ -196,7 +196,7 @@ function Strings.crop(text, size, appendEllipsisAtTheEnd)
 		return
 	end
 
-	assert(isType(size, "number", "size"));
+	Ellyb.Assertions.isType(size, "number", "size");
 	assert(size > 0, "Size has to be a positive number.");
 
 	if appendEllipsisAtTheEnd == nil then
@@ -225,7 +225,7 @@ end
 
 local BYTES_MULTIPLES = { 'Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB' };
 function Strings.formatBytes(bytes)
-	assert(isType(bytes, "number", "bytes"));
+	Ellyb.Assertions.isType(bytes, "number", "bytes");
 
 	if bytes < 2 then
 		return bytes .. ' Byte';
@@ -242,8 +242,8 @@ end
 ---@param separator string @ A separator
 ---@return string[] textContent @ A table of strings
 function Strings.split(text, separator)
-	assert(isType(text, "string", "text"));
-	assert(isType(separator, "string", "separator"));
+	Ellyb.Assertions.isType(text, "string", "text");
+	Ellyb.Assertions.isType(separator, "string", "separator");
 
 	local t = {}
 	local fpat = "(.-)" .. separator

--- a/Tools/Tables.lua
+++ b/Tools/Tables.lua
@@ -36,14 +36,14 @@ end
 ---@param source table @ The table that contains the thing we want to put in the destination
 ---@overload fun(source:table)
 function Tables.copy(destination, source)
-	assert(isType(destination, "table", "destination"));
+	Ellyb.Assertions.isType(destination, "table", "destination");
 
 	-- If we are only given one table, the that table is the source a new table is the destination
 	if not source then
 		source = destination;
 		destination = {};
 	else
-		assert(isType(source, "table", "source"));
+		Ellyb.Assertions.isType(source, "table", "source");
 	end
 
 	for k, v in pairs(source) do
@@ -63,7 +63,7 @@ end
 ---@param table table
 ---@param number tableSize @ The size of the table
 function Tables.size(table)
-	assert(isType(table, "table", "table"));
+	Ellyb.Assertions.isType(table, "table", "table");
 	-- We try to use #table first
 	local tableSize = #table;
 	if tableSize == 0 then
@@ -81,7 +81,7 @@ end
 ---@param object any @ The object that should be removed
 ---@return boolean hasBeenRemoved @ Return true if the object is found
 function Tables.remove(table, object)
-	assert(isType(table, "table", "table"));
+	Ellyb.Assertions.isType(table, "table", "table");
 	assert(isNotNil(object, "object"));
 
 	for index, value in pairs(table) do
@@ -97,7 +97,7 @@ end
 ---@param table table
 ---@return table tableKeys @ A new table that contains the keys of the given table
 function Tables.keys(table)
-	assert(isType(table, "table", "table"));
+	Ellyb.Assertions.isType(table, "table", "table");
 	local keys = {};
 	for key, _ in pairs(table) do
 		tinsert(keys, key);
@@ -109,7 +109,7 @@ end
 ---@param table table @ A table to check
 ---@return boolean isEmpty @ Returns true if the table is empty
 function Tables.isEmpty(table)
-	assert(isType(table, "table", "table"));
+	Ellyb.Assertions.isType(table, "table", "table");
 	local isEmpty = not next(table);
 	return isEmpty;
 end
@@ -132,7 +132,7 @@ end
 --- Release a temp table.
 ---@param table table
 function Tables.releaseTempTable(table)
-	assert(isType(table, "table", "table"));
+	Ellyb.Assertions.isType(table, "table", "table");
 	TABLE_POOL[table] = true;
 end
 
@@ -145,7 +145,7 @@ local TABLE_VALUE_TO_STRING = "[%q]=%s,"
 ---@param table table @ A valid table
 ---@return string stringTable @ A string representation of the table in Lua syntax
 function Tables.toString(table)
-	assert(isType(table, "table", "table"));
+	Ellyb.Assertions.isType(table, "table", "table");
 
 	local t = "{";
 	for key, value in pairs(table) do

--- a/Tools/Tables.lua
+++ b/Tools/Tables.lua
@@ -13,15 +13,10 @@ local type = type;
 local pairs = pairs;
 local wipe = wipe;
 local next = next;
-local assert = assert;
 local setmetatable = setmetatable;
 
 local Tables = {};
 Ellyb.Tables = Tables;
-
--- Ellyb imports
-local isType = Ellyb.Assertions.isType;
-local isNotNil = Ellyb.Assertions.isNotNil;
 
 ---Make use of WoW's shiny new table inspector window to inspect a table programatically
 ---@param table table @ The table we want to inspect in WoW's table inspector
@@ -82,7 +77,7 @@ end
 ---@return boolean hasBeenRemoved @ Return true if the object is found
 function Tables.remove(table, object)
 	Ellyb.Assertions.isType(table, "table", "table");
-	assert(isNotNil(object, "object"));
+	Ellyb.Assertions.isNotNil(object, "object");
 
 	for index, value in pairs(table) do
 		if value == object then

--- a/UI/Cursor.lua
+++ b/UI/Cursor.lua
@@ -68,7 +68,7 @@ end);
 ---@param optional x number @ A custom horizontal offset for the icon (default is 33)
 ---@param optional y number @ A custom vertical offset for the icon (default is -3)
 function Cursor:SetIcon(cursorTexture, x, y)
-	assert(Ellyb.Assertions.isOfTypes(cursorTexture, { "string", "number" }, "cursorTexture"));
+	Ellyb.Assertions.isOfTypes(cursorTexture, { "string", "number" }, "cursorTexture");
 
 	Icon:SetTexture(cursorTexture);
 	Icon:SetPoint("TOPLEFT", x or DEFAULT_ANCHOR_X, y or DEFAULT_ANCHOR_Y);

--- a/UI/Cursor.lua
+++ b/UI/Cursor.lua
@@ -6,7 +6,6 @@ if Ellyb.Cursor then
 end
 
 --region Lua imports
-local assert = assert;
 local insert = table.insert;
 local time = time;
 local pairs = pairs;

--- a/UI/Frames.lua
+++ b/UI/Frames.lua
@@ -5,15 +5,6 @@ if Ellyb.Frames then
 	return
 end
 
--- Lua imports
-local assert = assert;
-
--- Ellyb imports
-local isType = Ellyb.Assertions.isType;
-
--- WoW imports
-local ValidateFramePosition = ValidateFramePosition;
-
 local Frames = {};
 
 ---Make a frame movable. The frame's position is not saved.

--- a/UI/Frames.lua
+++ b/UI/Frames.lua
@@ -20,7 +20,7 @@ local Frames = {};
 ---@param frame Frame|ScriptObject
 ---@param validatePositionOnDragStop boolean
 function Frames.makeMovable(frame, validatePositionOnDragStop)
-	assert(isType(frame, "Frame", "frame"));
+	Ellyb.Assertions.isType(frame, "Frame", "frame");
 	frame:RegisterForDrag("LeftButton");
 	frame:EnableMouse(true);
 	frame:SetMovable(true);
@@ -55,8 +55,8 @@ end
 ---@param frame Frame @ The frame that will receive the scroll wheel event
 ---@param slider Slider @ The slider that should see its value changed
 function Frames.handleMouseWheelScroll(frame, slider)
-	assert(isType(frame, "Frame", frame));
-	assert(isType(slider, "Slider", slider));
+	Ellyb.Assertions.isType(frame, "Frame", frame);
+	Ellyb.Assertions.isType(slider, "Slider", slider);
 
 	frame._slider = slider;
 	frame:SetScript("OnMouseWheel", setSliderValueOnMouseScroll);


### PR DESCRIPTION
Improved Assertions module so the callers no longer have to pass the result of the module's methods to an `assert()` call. The assertions will generate the error messages themselves, reporting the parent level as generating the error.

Since the error messages are now only generated when an actual error is raised, assertions are now always evaluated, even when not in debug mode.