### PR TITLE
Leftover bugfixes from the middleclass revert

### DIFF
--- a/Tools/Assertions.lua
+++ b/Tools/Assertions.lua
@@ -24,7 +24,7 @@ end
 
 ---@param variable MiddleClass_Class
 local function isAClass(variable)
-	return type(variable) == "table" and type(variable.IsInstanceOf) == "function"
+	return type(variable) == "table" and type(variable.isInstanceOf) == "function"
 end
 
 ---@param t table
@@ -107,7 +107,7 @@ function Assertions.isInstanceOf(variable, class, variableName)
 	if not isAClass(variable) then
 		throw(([[Invalid type "%s" for variable "%s", expected a "%s".]]):format(type(variable), variableName, tostring(class)))
 	end
-	if not variable:IsInstanceOf(class) then
+	if not variable:isInstanceOf(class) then
 		throw(([[Invalid Class "%s" for variable "%s", expected "%s".]]):format(tostring(variable.class), variableName, tostring(class)))
 	end
 	return true

--- a/Tools/Colors.lua
+++ b/Tools/Colors.lua
@@ -342,7 +342,7 @@ function Color.static.CreateFromRGBAAsBytes(red, green, blue, alpha, alphaIsNotB
 	end
 
 	-- Set the values
-	color:SetRGBA(red, green, blue, alpha);
+	color:SetRGBA(red / 255, green / 255, blue / 255, alpha);
 	return color;
 end
 


### PR DESCRIPTION
- In CreateFromRGBAAsBytes, red/green/blue ranges weren't properly set between 0 and 1 in the call to SetRGBA.
- In the isInstanceOf assertion, an uppercase `I` at the start of the calls was leftover from the rewrite and caused every instance assertion to return false.