### PR TITLE
Remove per-handler log message

### DIFF
--- a/Tools/EventsDispatcher.lua
+++ b/Tools/EventsDispatcher.lua
@@ -17,8 +17,6 @@ local private = Ellyb.getPrivateStorage();
 
 local LOG_EVENT_REGISTERED = [[Registered new callback for event "%s" with handler ID "%s".]];
 local LOG_EVENT_UNREGISTERED = [[Registered event callback with handler ID "%s" for event "%s".]];
-local LOG_EVENT_FIRED_CALLBACK_FOR_EVENT = [[Fired event callback with handler ID "%s" for event "%s".
-Parameters:]];
 
 function EventsDispatcher:initialize()
 	private[self].callbackRegistry = {};
@@ -72,7 +70,7 @@ function EventsDispatcher:TriggerEvent(event, ...)
 	Ellyb.Assertions.isType(event, "string", "event")
 	local registry = private[self].callbackRegistry[event];
 	if registry then
-		for handlerID, callback in pairs(registry) do
+		for _, callback in pairs(registry) do
 			callback(...);
 		end
 	end

--- a/Tools/EventsDispatcher.lua
+++ b/Tools/EventsDispatcher.lua
@@ -74,7 +74,6 @@ function EventsDispatcher:TriggerEvent(event, ...)
 	if registry then
 		for handlerID, callback in pairs(registry) do
 			callback(...);
-			Logger:Info(LOG_EVENT_FIRED_CALLBACK_FOR_EVENT:format(handlerID, event), ...);
 		end
 	end
 end


### PR DESCRIPTION
This is incredibly spammy and as there's no log browser built in it makes any use of the Logs tab practically impossible, as when used by TRP we get events flying through this for practically everything.

I'd recommend that any code that really needs to log handler should instead do it themselves _within_ the handler functions, rather than force it upon them all without a say in the matter.