### PR TITLE
#35 Re-allow promises to get resolved again

### DIFF
--- a/Ellyb.lua
+++ b/Ellyb.lua
@@ -4,7 +4,7 @@ local AddOnName = ...;
 local pairs = pairs;
 -- local assert = assert;
 
-local VERSION_NUMBER = 10;
+local VERSION_NUMBER = 11;
 local DEBUG_MODE = true;
 local instances = {};
 local addonVersions = {};

--- a/Tools/Promise.lua
+++ b/Tools/Promise.lua
@@ -77,12 +77,6 @@ function Promise:Always(callback)
 end
 
 function Promise:Resolve(...)
-	if self:GetStatus() == Ellyb.Promises.STATUS.FULFILLED then
-		return error("Trying to resolve a Promise that has already been resolved.");
-	elseif self:GetStatus() == Ellyb.Promises.STATUS.REJECTED then
-		return error("Trying to resolve a Promise that has already been rejected.");
-	end
-
 	private[self].status = Ellyb.Promises.STATUS.FULFILLED;
 	private[self].resolutionArgs = { ...};
 


### PR DESCRIPTION
Storyline was relying on Promises being able to be resolved multiple times (like a notification system). Until this can be properly handled, reverted the check so we allow once again Promises to be resolved more than once.