### PR TITLE
Don't prevent dispatching events on error

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3857,6 +3857,7 @@ read_globals = {
 	"ButtonInventorySlot",
 	"CRFFlowFilterFunc",
 	"CRFGroupFilterFunc",
+	"CallErrorHandler",
 	"CallRestrictedClosure",
 	"CanCooperateWithToon",
 	"CanCreateFilters",

--- a/Tools/EventsDispatcher.lua
+++ b/Tools/EventsDispatcher.lua
@@ -71,7 +71,7 @@ function EventsDispatcher:TriggerEvent(event, ...)
 	local registry = private[self].callbackRegistry[event];
 	if registry then
 		for _, callback in pairs(registry) do
-			callback(...);
+			xpcall(callback, CallErrorHandler, ...);
 		end
 	end
 end


### PR DESCRIPTION
If an error is raised by callback we'll pass it through the standard error handler (via CallErrorHandler) so it gets picked up by error catching tools, but we won't terminate execution of the loop.